### PR TITLE
Add DB environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Create a `.env` file in the project root or export these variables in your shell
 - `SECRET_KEY` – Django secret key.
 - `DEBUG` – set to `True` or `False` (default is `True`).
 - `ALLOWED_HOSTS` – comma separated list of allowed hosts.
+- `DB_NAME` – (optional) PostgreSQL database name, default `crm_db`.
+- `DB_USER` – (optional) PostgreSQL user, default `grand21`.
 - `DB_PASSWORD` – password for the PostgreSQL user.
+- `DB_HOST` – (optional) database host, default `localhost`.
+- `DB_PORT` – (optional) database port, default `5432`.
 - `TELEGRAM_BOT_TOKEN` – token for the public bot.
 - `TELEGRAM_BOT_TOKEN_PRIVATE` – token for the private bot.
 - `CELERY_BROKER_URL` – (optional) URL of the Celery broker, default `redis://127.0.0.1:6379/0`.

--- a/config/settings.py
+++ b/config/settings.py
@@ -77,14 +77,20 @@ DB_PASSWORD = os.getenv("DB_PASSWORD")
 if not DB_PASSWORD:
     raise ValueError("DB_PASSWORD is missing! Please add it to .env file.")
 
+# Database configuration with environment variable overrides
+DB_NAME = os.getenv("DB_NAME", "crm_db")
+DB_USER = os.getenv("DB_USER", "grand21")
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = os.getenv("DB_PORT", "5432")
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "crm_db",
-        "USER": "grand21",
+        "NAME": DB_NAME,
+        "USER": DB_USER,
         "PASSWORD": DB_PASSWORD,
-        "HOST": "localhost",
-        "PORT": "5432",
+        "HOST": DB_HOST,
+        "PORT": DB_PORT,
     }
 }
 


### PR DESCRIPTION
## Summary
- allow overriding DB settings with environment variables
- document the new variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68427686c17c8320b18dfb5ce14a270e