### PR TITLE
Fix .gitignore systemctl pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ Thumbs.db
 # VS Code/etc
 .vscode/
 .idea/
-ystemctl*
+systemctl*


### PR DESCRIPTION
## Summary
- fix `.gitignore` pattern for systemctl files

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6842776619e08320bbde7ee913e8faef