### PR TITLE
Fix broadcast message template to load buttons widget

### DIFF
--- a/static/js/buttons_widget.js
+++ b/static/js/buttons_widget.js
@@ -1,0 +1,68 @@
+// JS widget to build inline keyboard buttons on the BroadcastMessage admin page
+
+document.addEventListener('DOMContentLoaded', function () {
+    const addBtn = document.getElementById('add-button');
+    const container = document.getElementById('button-builder');
+    const textsInput = document.getElementById('id_button_texts');
+    const urlsInput = document.getElementById('id_button_urls');
+    const typesInput = document.getElementById('id_button_types');
+
+    function updateHiddenFields() {
+        const texts = [];
+        const urls = [];
+        const types = [];
+        container.querySelectorAll('.button-row').forEach(row => {
+            const text = row.querySelector('.btn-text').value;
+            const url = row.querySelector('.btn-url').value;
+            const type = row.querySelector('.btn-type').value;
+            if (text && url && type) {
+                texts.push(text);
+                urls.push(url);
+                types.push(type);
+            }
+        });
+        textsInput.value = texts.join('|||');
+        urlsInput.value = urls.join('|||');
+        typesInput.value = types.join('|||');
+    }
+
+    function createButtonRow(text = '', url = '', type = 'url') {
+        const row = document.createElement('div');
+        row.className = 'button-row';
+        row.innerHTML = `
+            <input type="text" placeholder="Текст" class="btn-text" value="${text}" style="margin-right:5px;" />
+            <input type="text" placeholder="URL/Callback" class="btn-url" value="${url}" style="margin-right:5px;" />
+            <select class="btn-type" style="margin-right:5px;">
+                <option value="url">url</option>
+                <option value="callback">callback</option>
+            </select>
+            <button type="button" class="remove-btn">✖</button>
+        `;
+        row.querySelector('.btn-text').addEventListener('input', updateHiddenFields);
+        row.querySelector('.btn-url').addEventListener('input', updateHiddenFields);
+        row.querySelector('.btn-type').addEventListener('change', updateHiddenFields);
+        row.querySelector('.remove-btn').addEventListener('click', () => {
+            row.remove();
+            updateHiddenFields();
+        });
+        row.querySelector('.btn-type').value = type;
+        container.appendChild(row);
+    }
+
+    const savedTexts = textsInput.value ? textsInput.value.split('|||') : [];
+    const savedUrls = urlsInput.value ? urlsInput.value.split('|||') : [];
+    const savedTypes = typesInput.value ? typesInput.value.split('|||') : [];
+    const max = Math.max(savedTexts.length, savedUrls.length, savedTypes.length);
+    for (let i = 0; i < max; i++) {
+        if (savedTexts[i] || savedUrls[i] || savedTypes[i]) {
+            createButtonRow(savedTexts[i] || '', savedUrls[i] || '', savedTypes[i] || 'url');
+        }
+    }
+
+    addBtn.addEventListener('click', function (e) {
+        e.preventDefault();
+        createButtonRow();
+    });
+
+    updateHiddenFields();
+});

--- a/templates/admin/core/broadcastmessage/change_form.html
+++ b/templates/admin/core/broadcastmessage/change_form.html
@@ -1,11 +1,21 @@
 {% extends "admin/change_form.html" %}
 {% load static %}
 
+{% block extrahead %}
+{{ block.super }}
+<style>
+    #button-builder { margin-top: 1em; }
+    .button-row { display: flex; gap: 5px; margin-bottom: 5px; }
+    .button-row input, .button-row select { padding: 4px; }
+</style>
+<script src="{% static 'js/buttons_widget.js' %}"></script>
+{% endblock %}
+
 {% block after_related_objects %}
-  {% if adminform.form.buttons_json.value %}
-    <div style="margin: 20px 0; padding: 10px; background: #f9f9f9; border: 1px solid #ccc;">
-      <h3>🔘 Кнопки</h3>
-      <pre>{{ adminform.form.buttons_json.value|safe }}</pre>
-    </div>
-  {% endif %}
+<div>
+    <h3>Кнопки для рассылки</h3>
+    <div id="button-builder"></div>
+    <button type="button" id="add-button">Добавить кнопку</button>
+</div>
+{{ block.super }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- update the BroadcastMessage admin template so the buttons widget is loaded
- add `static/js/buttons_widget.js` with widget logic

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684294dd94b88320930ae15369c5b106