### PR TITLE
Add Celery worker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,11 @@ python manage.py runbot_private  # runs tg_bots.bot_private
 ```
 
 Each command reads the required tokens from the environment variables described above.
+
+## Running the Celery worker
+
+To process broadcast tasks and handle conversions, start a Celery worker:
+
+```bash
+celery -A config worker -l info
+```


### PR DESCRIPTION
## Summary
- document how to start a Celery worker for broadcast tasks and conversions

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: SECRET_KEY and other env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844e42aa92883209e9cdf7794d4c211