### PR TITLE
Replace prints with logging

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -1,8 +1,11 @@
 import os
+import logging
 from celery import Celery
 
 # Установка переменной окружения Django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+logger = logging.getLogger(__name__)
 
 app = Celery("crm")
 
@@ -14,4 +17,4 @@ app.autodiscover_tasks()
 
 @app.task(bind=True)
 def debug_task(self):
-    print(f"Request: {self.request!r}")
+    logger.info(f"Request: {self.request!r}")

--- a/tg_bots/bot_private/send.py
+++ b/tg_bots/bot_private/send.py
@@ -1,6 +1,9 @@
 import asyncio
+import logging
 from telegram import Bot
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 bot = Bot(token=settings.TELEGRAM_BOT_TOKEN_PRIVATE)
 
@@ -15,5 +18,5 @@ async def _send_broadcast(broadcast):
             await bot.send_message(chat_id=client.user_id, text=broadcast.text)
             count += 1
         except Exception as e:
-            print(f"Ошибка при отправке {client.user_id}: {e}")
+            logger.error(f"Ошибка при отправке {client.user_id}: {e}")
     return count


### PR DESCRIPTION
## Summary
- get logger for celery tasks and use it
- set up logger for telegram bot broadcasts and log errors instead of printing

## Testing
- `python -m py_compile config/celery.py tg_bots/bot_private/send.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844e46afb0c832080549b60e143d96d