### PR TITLE
Fix redundant logger init

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -28,11 +28,14 @@ from .models import (
 )
 
 logger = logging.getLogger("broadcast")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(logging.Formatter("%(asctime)s | %(levelname)s | %(message)s"))
-logger.addHandler(handler)
-logger.info("✅ Логгер инициализирован в stdout")
+if not logger.handlers:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    )
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    logger.info("✅ Логгер инициализирован в stdout")
 
 
 class BroadcastDeliveryInline(admin.TabularInline):


### PR DESCRIPTION
## Summary
- avoid duplicate logger handlers in `core/admin.py`

## Testing
- `python manage.py check` *(fails: SECRET_KEY is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844e4691ae883208c985416fc548c08