### PR TITLE
Add course access API

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -2,11 +2,12 @@ from django.contrib import admin
 from django.urls import path
 from django.conf import settings
 from django.conf.urls.static import static
-from core.views import monitoring_page, metrics_api
+from core.views import monitoring_page, metrics_api, check_access_view
 
 urlpatterns = [
     path('adminka-193n/performance/', monitoring_page, name='admin_monitoring'),
     path('adminka-193n/monitor/api/', metrics_api, name='metrics_api'),
+    path('api/check-access/', check_access_view, name='check_access'),
     path('adminka-193n/', admin.site.urls),
 ]
 


### PR DESCRIPTION
## Summary
- implement `check_access_view` in `core.views`
- expose `/api/check-access/` route in `config.urls`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68501c7e9ea8832084a8341a2c4db226